### PR TITLE
Adding fixes for the errors listed on issue #17

### DIFF
--- a/docker_for_build/docker-entrypoint.sh
+++ b/docker_for_build/docker-entrypoint.sh
@@ -6,6 +6,8 @@ cp $MEICAN_DIR/docker_for_build/db.php $MEICAN_DIR/config/ \
  && sed -i "s/MYSQL_USER/$MYSQL_USER/" $MEICAN_DIR/config/db.php \
  && sed -i "s/MYSQL_PASSWORD/$MYSQL_PASSWORD/" $MEICAN_DIR/config/db.php \
  && chown meican:meican $MEICAN_DIR/config/db.php  \
+ && mkdir $MEICAN_DIR/vendor \
+ && chmod 777 $MEICAN_DIR/vendor $MEICAN_DIR/web/assets $MEICAN_DIR/runtime \
  && su meican -c "php composer.phar install" \
  && service apache2 start \
  && /bin/bash

--- a/migrations/m150901_152747_diego.php
+++ b/migrations/m150901_152747_diego.php
@@ -43,6 +43,7 @@ class m150901_152747_diego extends Migration
 	    	('createReservation', 2, NULL, NULL, NULL, 1417799563, 1417799563),
 	    	('createRole', 2, NULL, NULL, NULL, 1439221347, 1439221347),
 	    	('createSynchronizer', 2, NULL, NULL, NULL, 1439491351, 1439491351),
+                ('createSdxCircuit', 2, NULL, NULL, NULL, 1683900354, 1683900354),
 	    	('createTest', 2, NULL, NULL, NULL, 1439482385, 1439482385),
 	    	('createUser', 2, NULL, NULL, NULL, 1417799563, 1417799563),
 	    	('createWorkflow', 2, NULL, NULL, NULL, 1431101273, 1431101273),


### PR DESCRIPTION
Fixes #17 

### Description of the change

this PR provides fixes for two issues that were occurring in a clean setup environment:

1) migrations now also add the role `createSdxCircuit`

2) some steps that needs to be performed on the meican-sdx directory to avoid permission denied errors are now included in the build process 