### PR TITLE
change varchar(6) to text to allow high number of OXPs

### DIFF
--- a/migrations/m240912_143040_create_meican_user_topology_domain_table.php
+++ b/migrations/m240912_143040_create_meican_user_topology_domain_table.php
@@ -10,7 +10,7 @@ class m240912_143040_create_meican_user_topology_domain_table extends Migration
                 CREATE TABLE `meican_user_topology_domain` (
                         `id` int(11) NOT NULL,
                         `user_id` int(11) NOT NULL,
-                        `domain` varchar(60) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL
+                        `domain` text CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL
                       ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
                 ");
 


### PR DESCRIPTION
Fix #73 

### Description of the change

This pull request changes the type of allowed_domains from `varchar(60)` to text, which allow 65535 characters in the list of domains.

In the future we could change the behavior here to have each domain being a list on the database. Like this:

```
$ git diff modules/circuits/controllers/NodesController.php
diff --git a/modules/circuits/controllers/NodesController.php b/modules/circuits/controllers/NodesController.php
index c34b8f3e..377a61cf 100644
--- a/modules/circuits/controllers/NodesController.php
+++ b/modules/circuits/controllers/NodesController.php
@@ -63,9 +63,12 @@ class NodesController extends RbacController {
           ->select(['domain'])
           ->from('meican_user_topology_domain')
           ->where(['user_id' => $userId])
-          ->scalar();
+          ->all();

-      $allowedDomains = $associatedDomains ? explode(',', $associatedDomains) : [];
+      $allowedDomains = array();
+      foreach ($associatedDomains as $row) {
+        $allowedDomains[] = $row["domain"];
+      }

       /* Processing topology JSON */
       function find_subnode_by_id_refresh($nodes_array,$node_id){
@@ -479,9 +482,12 @@ class NodesController extends RbacController {
         ->select(['domain'])
         ->from('meican_user_topology_domain')
         ->where(['user_id' => $userId])
-        ->scalar();
+        ->all();

-    $allowedDomains = $associatedDomains ? explode(',', $associatedDomains) : [];
+    $allowedDomains = array();
+    foreach ($associatedDomains as $row) {
+      $allowedDomains[] = $row["domain"];
+    }

     /* Processing topology JSON */
     function find_subnode_by_id($nodes_array,$node_id){
```

But this would require some refactoring on the update function (./modules/aaa/controllers/UserController.php)