### PR TITLE
exposing MySQL running in the container on port 3306

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - db-meican:/var/lib/mysql
     env_file:
       - .env
+    ports:
+      - "3306:3306"
   
 volumes:
   db-meican:


### PR DESCRIPTION
Exposing MySQL container port to use meicandb for sdxlib jupyter notebook.