### PR TITLE
Fix hard-coded variables

### DIFF
--- a/modules/circuits/controllers/NodesController.php
+++ b/modules/circuits/controllers/NodesController.php
@@ -651,6 +651,7 @@ class NodesController extends RbacController {
       $enableCILogonPage = defined('ENABLE_CILOGON_PAGE') ? ENABLE_CILOGON_PAGE : false; // Cilogon environment variable
       $CILogonClientID=CILOGON_CLIENT_ID;
       $CILogonClientSecret=CILOGON_CLIENT_SECRET;
+      $SDX_ALLOWED_DOMAINS = defined('SDX_ALLOWED_DOMAINS') ? SDX_ALLOWED_DOMAINS : "ampath.net,sax.net,tenet.ac.za";
       $db = Yii::$app->db;
 
       if ($enableCILogonPage) { // Cilogon environment variable is enabled
@@ -909,7 +910,7 @@ class NodesController extends RbacController {
                                     Yii::$app->db->createCommand()->insert('meican_user_topology_domain', [
                                         'id' => $userId,
                                         'user_id' => $userId,
-                                        'domain' => 'ampath.net,sax.net,tenet.ac.za',
+                                        'domain' => $SDX_ALLOWED_DOMAINS,
                                     ])->execute();
                                 } catch (\yii\db\Exception $e) {
                                     echo "Insert failed: " . $e->getMessage();
@@ -936,7 +937,7 @@ class NodesController extends RbacController {
                   }
 
                   else{
-                      $email='test@test.com';
+                      $email="$trimmedOutput-TO-BE-CHANGED@localhost.localdomain";
                       $user = new User;
                       $user->login = $trimmedOutput;
                       $user->authkey = Yii::$app->getSecurity()->generateRandomString();
@@ -949,7 +950,7 @@ class NodesController extends RbacController {
                         $user->name = $response_arr['given_name'].' '.$response_arr['family_name'];
                       }
                       else {
-                        $user->name='userXYZ';
+                        $user->name=$response_arr['sub'];
                       }
                       $user->email = $email;
                       $registration_token=Yii::$app->getSecurity()->generateRandomString();

--- a/web/index.php
+++ b/web/index.php
@@ -9,9 +9,13 @@
 //defined('YII_ENV') or define('YII_ENV', 'dev');
 defined('MEICAN_URL') or define('MEICAN_URL', 'XXX_MEICAN_URL_XXX');
 defined('API_URL') or define('API_URL', 'XXX_SDX_CONTROLLER_URL_XXX');
+defined('ENABLE_ORCID_PAGE') or define('ENABLE_ORCID_PAGE', false); // ORCID environment variable
 defined('ORCID_CLIENT_ID') or define('ORCID_CLIENT_ID', 'XXX_ORCID_CLIENT_ID_XXX');
 defined('ORCID_CLIENT_SECRET') or define('ORCID_CLIENT_SECRET', 'XXX_ORCID_CLIENT_SECRET_XXX');
 defined('ENABLE_CILOGON_PAGE') or define('ENABLE_CILOGON_PAGE', true); // Cilogon environment variable for enabling/disabling cilogon
+defined('CILOGON_CLIENT_ID') or define('CILOGON_CLIENT_ID', 'XXX_CILOGON_CLIENT_ID_XXX'); // Cilogon environment variable for client ID
+defined('CILOGON_CLIENT_SECRET') or define('CILOGON_CLIENT_SECRET', 'XXX_CILOGON_CLIENT_SECRET_XXX'); // Cilogon environment variable for client secret
+defined('SDX_ALLOWED_DOMAINS') or define('SDX_ALLOWED_DOMAINS', 'ampath.net,sax.net,tenet.ac.za'); // List of domains to be allowed by default to all users
 
 require(__DIR__ . '/../vendor/autoload.php');
 require(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');


### PR DESCRIPTION
This PR fixes some hard-coded variables and this will help addressing three problems:

1) Conflicting e-mail addresses for users using `test@test.com`

2) Different setups that have different DOMAINs from the ones hard-coded (i.e, `ampath.net,sax.net,tenet.ac.za`)

3) general improvement on the configuration and documentation of the variables, centralizing everything on the `web/index.php` file